### PR TITLE
Fix for ios Podfile requiring 12.0 in order to use FBSDKCoreKit 17. Fixes #12

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -110,6 +110,7 @@
             <access origin="https://api.facebook.com" />
             <access origin="https://*.fbcdn.net" />
             <access origin="https://*.akamaihd.net" />
+            <preference name="deployment-target" value="12.0" />
         </config-file>
 
         <header-file src="src/ios/FacebookConnectPlugin.h" />


### PR DESCRIPTION
Adds
```xml
 <preference name="deployment-target" value="12.0" />
```